### PR TITLE
Backup and restore persistence object from AWS S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY jiobot /app/jiobot
 COPY main.py /app/main.py
 
 # Run server
-CMD ["python", "main.py"]
+ENTRYPOINT ["python", "main.py"]

--- a/main.py
+++ b/main.py
@@ -100,4 +100,4 @@ if __name__ == "__main__":
     logging.info(f"Uploading {persistence_file} to AWS S3.")
     s3 = boto3.resource('s3')
     s3.meta.client.upload_file(persistence_file, INSTANCE_ID, persistence_file)
-    logging.debug(f"{persistence_file} was successfully uploaded!")
+    logging.debug(f"File {persistence_file} was successfully uploaded!")

--- a/main.py
+++ b/main.py
@@ -18,8 +18,11 @@ if __name__ == "__main__":
     )
     logging.info(f"Instance ID: {INSTANCE_ID}")
 
+    # Set name of persistence data file
+    persistence_file = "data/persistence.pickle"
+
     # Initialise persistence object
-    pp = PicklePersistence(filename='data/persistence.pickle')
+    pp = PicklePersistence(filename=persistence_file)
 
     # Initialise updater and dispatcher
     up = Updater(token=TELEGRAM_BOT_API_TOKEN, persistence=pp, use_context=True)

--- a/main.py
+++ b/main.py
@@ -33,12 +33,19 @@ if __name__ == "__main__":
     # Set name of persistence data file
     persistence_file = "data/persistence.pickle"
 
-    # Download file if not exists
+    # Check if persistence file exists
     if not os.path.isfile(persistence_file):
-        logging.info(f"File {persistence_file} was not found, downloading from AWS S3.")
-        s3 = boto3.resource('s3')
-        s3.meta.client.download_file(INSTANCE_ID, persistence_file, persistence_file)
-        logging.debug(f"{persistence_file} was successfully downloaded!")
+        logging.error(f"File {persistence_file} was not found!")
+
+        # Warn that new file will be created
+        if args.first_run:
+            logging.warning(f"File {persistence_file} will be newly created since --first-run={args.first_run}")
+
+        # Get file from AWS S3 if not first time
+        else:
+            s3 = boto3.resource('s3')
+            s3.meta.client.download_file(INSTANCE_ID, persistence_file, persistence_file)
+            logging.debug(f"File {persistence_file} was successfully downloaded!")
 
     # Initialise persistence object
     pp = PicklePersistence(filename=persistence_file)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+import boto3
 from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackQueryHandler, ConversationHandler, PicklePersistence
 
 from jiobot.handlers import commands, fallback
@@ -71,3 +72,9 @@ if __name__ == "__main__":
     # Run the bot until the user presses Ctrl-C or the process receives SIGINT,
     # SIGTERM or SIGABRT
     up.idle()
+
+    # Backup latest file to AWS
+    logging.info(f"Uploading {persistence_file} to AWS S3.")
+    s3 = boto3.resource('s3')
+    s3.meta.client.upload_file(persistence_file, INSTANCE_ID, persistence_file)
+    logging.debug(f"{persistence_file} was successfully uploaded!")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import argparse
 
 import boto3
 from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackQueryHandler, ConversationHandler, PicklePersistence
@@ -18,6 +19,16 @@ if __name__ == "__main__":
         level=logging.DEBUG,
     )
     logging.info(f"Instance ID: {INSTANCE_ID}")
+
+    # Define parser
+    parser = argparse.ArgumentParser(description='JioBot Telegram Bot')
+
+    # Add optional argument
+    parser.add_argument("--first-run", action="store_true", help="Initialise files for first run")
+
+    # Parse args
+    args = parser.parse_args()
+    logging.debug(f"Parsed arguments: {args}")
 
     # Set name of persistence data file
     persistence_file = "data/persistence.pickle"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from jiobot.handlers import commands, fallback
 from jiobot.handlers.conversation import newevent
 
 TELEGRAM_BOT_API_TOKEN = os.environ["TELEGRAM_BOT_API_TOKEN"]
+INSTANCE_ID = os.environ["INSTANCE_ID"]
 
 
 if __name__ == "__main__":
@@ -15,6 +16,7 @@ if __name__ == "__main__":
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         level=logging.DEBUG,
     )
+    logging.info(f"Instance ID: {INSTANCE_ID}")
 
     # Initialise persistence object
     pp = PicklePersistence(filename='data/persistence.pickle')

--- a/main.py
+++ b/main.py
@@ -41,8 +41,6 @@ if __name__ == "__main__":
         logging.debug(f"{persistence_file} was successfully downloaded!")
 
     # Initialise persistence object
-    if not os.path.isfile(persistence_file):
-        raise FileNotFoundError(f"{persistence_file} cannot be found!")
     pp = PicklePersistence(filename=persistence_file)
 
     # Initialise updater and dispatcher

--- a/main.py
+++ b/main.py
@@ -22,6 +22,13 @@ if __name__ == "__main__":
     # Set name of persistence data file
     persistence_file = "data/persistence.pickle"
 
+    # Download file if not exists
+    if not os.path.isfile(persistence_file):
+        logging.info(f"File {persistence_file} was not found, downloading from AWS S3.")
+        s3 = boto3.resource('s3')
+        s3.meta.client.download_file(INSTANCE_ID, persistence_file, persistence_file)
+        logging.debug(f"{persistence_file} was successfully downloaded!")
+
     # Initialise persistence object
     if not os.path.isfile(persistence_file):
         raise FileNotFoundError(f"{persistence_file} cannot be found!")

--- a/main.py
+++ b/main.py
@@ -10,18 +10,18 @@ TELEGRAM_BOT_API_TOKEN = os.environ["TELEGRAM_BOT_API_TOKEN"]
 
 
 if __name__ == "__main__":
+    # Initialise logging module
+    logging.basicConfig(
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        level=logging.DEBUG,
+    )
+
     # Initialise persistence object
     pp = PicklePersistence(filename='data/persistence.pickle')
 
     # Initialise updater and dispatcher
     up = Updater(token=TELEGRAM_BOT_API_TOKEN, persistence=pp, use_context=True)
     dp = up.dispatcher
-
-    # Initialise logging module
-    logging.basicConfig(
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        level=logging.DEBUG,
-    )
 
     # Command Handlers
     dp.add_handler(CommandHandler('start', commands.start))

--- a/main.py
+++ b/main.py
@@ -22,6 +22,8 @@ if __name__ == "__main__":
     persistence_file = "data/persistence.pickle"
 
     # Initialise persistence object
+    if not os.path.isfile(persistence_file):
+        raise FileNotFoundError(f"{persistence_file} cannot be found!")
     pp = PicklePersistence(filename=persistence_file)
 
     # Initialise updater and dispatcher

--- a/main.py
+++ b/main.py
@@ -30,6 +30,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logging.debug(f"Parsed arguments: {args}")
 
+    # Create AWS S3 resource object
+    s3 = boto3.resource('s3')
+
     # Set name of persistence data file
     persistence_file = "data/persistence.pickle"
 
@@ -43,7 +46,6 @@ if __name__ == "__main__":
 
         # Get file from AWS S3 if not first time
         else:
-            s3 = boto3.resource('s3')
             s3.meta.client.download_file(INSTANCE_ID, persistence_file, persistence_file)
             logging.debug(f"File {persistence_file} was successfully downloaded!")
 
@@ -98,6 +100,5 @@ if __name__ == "__main__":
 
     # Backup latest file to AWS
     logging.info(f"Uploading {persistence_file} to AWS S3.")
-    s3 = boto3.resource('s3')
     s3.meta.client.upload_file(persistence_file, INSTANCE_ID, persistence_file)
     logging.debug(f"File {persistence_file} was successfully uploaded!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,16 @@
 asn1crypto==0.24.0
+boto3==1.9.224
+botocore==1.12.224
 certifi==2019.6.16
 cffi==1.12.3
 cryptography==2.7
+docutils==0.15.2
 future==0.17.1
+jmespath==0.9.4
 pycparser==2.19
+python-dateutil==2.8.0
 python-telegram-bot==12.0.0
+s3transfer==0.2.1
 six==1.12.0
 tornado==6.0.3
+urllib3==1.25.3


### PR DESCRIPTION
This PR gives the flexibility of backup and restoring, at least for now the main persistence pickle object, to and from AWS S3. This ensures that even if the volume mounted for the container is ever corrupted, the current volume can deleted and the latest pickle object can be retrieved from AWS S3.